### PR TITLE
alpha4 publishMsg overload

### DIFF
--- a/MQTT Client driver
+++ b/MQTT Client driver
@@ -175,6 +175,10 @@ def publishMsg(String topic, String payload,int qos = 1, boolean retained = fals
     
 }
 
+def publishMsg(String topic, String payload, int qos, String retained) {
+    publishMsg(topic, payload, qos, retained.toBoolean())
+}
+
 def subscribeTopic (String s) {
 	log ("MQTT subscribing to: " + s, "INFO")
     if (state.connected==true){


### PR DESCRIPTION
Add an overload for publishMsg that makes it possible to pass all 4 parameters from a RM action despite the latter's lack of support for the boolean type.